### PR TITLE
Windows 7 / Powershell 2 compatibility

### DIFF
--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -63,7 +63,7 @@ class Clipboard
 				} else {
 					// https://github.com/Microsoft/WSL/issues/1069
 					// slower
-					$this->pasteCmdArgs = 'powershell.exe -Command Get-Clipboard';
+					$this->pasteCmdArgs = 'powershell -sta "add-type -as System.Windows.Forms; [windows.forms.clipboard]::GetText()"';
 				}
 				$this->copyCmdArgs = 'clip';
 				break;


### PR DESCRIPTION
Get-Clipboard was introduced in PowerShell 3, which means it won't work on your average Windows 7 system.
the old code is PS3+ compatible, and the new code is PS2+ compatible.

Edit: this should also make it Vista/XP/Server 2003/Server 2008 compatible, but the oldest i've actually tested is 7.